### PR TITLE
Update SettingsVC

### DIFF
--- a/Cineaste.xcodeproj/project.pbxproj
+++ b/Cineaste.xcodeproj/project.pbxproj
@@ -46,6 +46,8 @@
 		3FCC71371FD7536B00A47ADF /* FetchedResultsManagerDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FCC71361FD7536B00A47ADF /* FetchedResultsManagerDelegate.swift */; };
 		3FD2F87D201E04AD003B880E /* MoviesViewController+SwipeAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FD2F87C201E04AD003B880E /* MoviesViewController+SwipeAction.swift */; };
 		3FD886461FF2C46400A86ACF /* Appearance.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FD886451FF2C46400A86ACF /* Appearance.swift */; };
+		3FEF5C492030B28100EFCAA2 /* SettingsViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FEF5C482030B28100EFCAA2 /* SettingsViewControllerTests.swift */; };
+		3FEF5C4B2030B28D00EFCAA2 /* SettingsCellTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FEF5C4A2030B28D00EFCAA2 /* SettingsCellTests.swift */; };
 		45E30914AA64816E9D8F1F02 /* Pods_Cineaste.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DD83ED5B07D59B9D83B9F446 /* Pods_Cineaste.framework */; };
 		634BFA4AFCFA1EDED2BA139C /* Pods_CineasteTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 614D56475F502CF4C5A24355 /* Pods_CineasteTests.framework */; };
 		9528112E201D05AD00F3EC76 /* Result.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9528112D201D05AD00F3EC76 /* Result.swift */; };
@@ -123,6 +125,8 @@
 		3FCC71361FD7536B00A47ADF /* FetchedResultsManagerDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FetchedResultsManagerDelegate.swift; sourceTree = "<group>"; };
 		3FD2F87C201E04AD003B880E /* MoviesViewController+SwipeAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MoviesViewController+SwipeAction.swift"; sourceTree = "<group>"; };
 		3FD886451FF2C46400A86ACF /* Appearance.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Appearance.swift; sourceTree = "<group>"; };
+		3FEF5C482030B28100EFCAA2 /* SettingsViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsViewControllerTests.swift; sourceTree = "<group>"; };
+		3FEF5C4A2030B28D00EFCAA2 /* SettingsCellTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsCellTests.swift; sourceTree = "<group>"; };
 		614D56475F502CF4C5A24355 /* Pods_CineasteTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_CineasteTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		93847470A61BB0CE79904886 /* Pods-Cineaste.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Cineaste.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Cineaste/Pods-Cineaste.debug.xcconfig"; sourceTree = "<group>"; };
 		9528112D201D05AD00F3EC76 /* Result.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Result.swift; sourceTree = "<group>"; };
@@ -316,6 +320,8 @@
 				3F83BE991FF3CA1700E584E9 /* SearchMoviesSourceTests.swift */,
 				3F83BE8F1FF3B29D00E584E9 /* SearchMoviesCellTests.swift */,
 				3F8C569D1FFACB2600F09A82 /* MovieStorageTests.swift */,
+				3FEF5C482030B28100EFCAA2 /* SettingsViewControllerTests.swift */,
+				3FEF5C4A2030B28D00EFCAA2 /* SettingsCellTests.swift */,
 			);
 			path = CineasteTests;
 			sourceTree = "<group>";
@@ -684,9 +690,11 @@
 				3F8644B31FFA96370046114A /* MoviesViewControllerTests.swift in Sources */,
 				3F83BE901FF3B29D00E584E9 /* SearchMoviesCellTests.swift in Sources */,
 				3F83BE821FF3AE3700E584E9 /* MovieListCellTests.swift in Sources */,
+				3FEF5C492030B28100EFCAA2 /* SettingsViewControllerTests.swift in Sources */,
 				3F83BE801FF3AC3B00E584E9 /* CoreDataHelper.swift in Sources */,
 				3F8644B11FFA95190046114A /* MoviesTabBarControllerTests.swift in Sources */,
 				3F83BE9A1FF3CA1700E584E9 /* SearchMoviesSourceTests.swift in Sources */,
+				3FEF5C4B2030B28D00EFCAA2 /* SettingsCellTests.swift in Sources */,
 				3F8C569E1FFACB2600F09A82 /* MovieStorageTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Cineaste.xcodeproj/project.pbxproj
+++ b/Cineaste.xcodeproj/project.pbxproj
@@ -15,6 +15,7 @@
 		3F5E0D8C20308FF700E091BE /* SettingsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F5E0D8B20308FF700E091BE /* SettingsViewController.swift */; };
 		3F5E0D8F2030905B00E091BE /* SettingsCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F5E0D8E2030905B00E091BE /* SettingsCell.swift */; };
 		3F5E0D91203090C300E091BE /* SettingItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F5E0D90203090C300E091BE /* SettingItem.swift */; };
+		3F5E0D932030988E00E091BE /* TextViewContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F5E0D922030988E00E091BE /* TextViewContent.swift */; };
 		3F61B2FB1FFAD680007A0557 /* MoviesList.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 3F61B2FD1FFAD680007A0557 /* MoviesList.storyboard */; };
 		3F6C88792002B2C50052BF24 /* ImprintViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F6C88782002B2C50052BF24 /* ImprintViewController.swift */; };
 		3F6C887C2002B2FC0052BF24 /* Settings.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 3F6C887A2002B2FC0052BF24 /* Settings.storyboard */; };
@@ -90,6 +91,7 @@
 		3F5E0D8B20308FF700E091BE /* SettingsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsViewController.swift; sourceTree = "<group>"; };
 		3F5E0D8E2030905B00E091BE /* SettingsCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsCell.swift; sourceTree = "<group>"; };
 		3F5E0D90203090C300E091BE /* SettingItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingItem.swift; sourceTree = "<group>"; };
+		3F5E0D922030988E00E091BE /* TextViewContent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextViewContent.swift; sourceTree = "<group>"; };
 		3F61B2FC1FFAD680007A0557 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/MoviesList.storyboard; sourceTree = "<group>"; };
 		3F61B2FF1FFAD683007A0557 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/MoviesList.strings; sourceTree = "<group>"; };
 		3F6C88782002B2C50052BF24 /* ImprintViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImprintViewController.swift; sourceTree = "<group>"; };
@@ -373,6 +375,7 @@
 				9552262C1FAFB5D300323982 /* StoredMovie.swift */,
 				95B57719201E2C75007BD9F0 /* MovieListCategory.swift */,
 				3F5E0D90203090C300E091BE /* SettingItem.swift */,
+				3F5E0D922030988E00E091BE /* TextViewContent.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -639,6 +642,7 @@
 				3FCC71371FD7536B00A47ADF /* FetchedResultsManagerDelegate.swift in Sources */,
 				3F8644AB1FFA72EE0046114A /* MoviesTabBarController.swift in Sources */,
 				3F5E0D91203090C300E091BE /* SettingItem.swift in Sources */,
+				3F5E0D932030988E00E091BE /* TextViewContent.swift in Sources */,
 				95B5771A201E2C75007BD9F0 /* MovieListCategory.swift in Sources */,
 				9552262D1FAFB5D300323982 /* StoredMovie.swift in Sources */,
 				9528112E201D05AD00F3EC76 /* Result.swift in Sources */,

--- a/Cineaste.xcodeproj/project.pbxproj
+++ b/Cineaste.xcodeproj/project.pbxproj
@@ -12,9 +12,12 @@
 		3F1292F21FD7C90D00ED5593 /* Search.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 3F1292EF1FD7C90C00ED5593 /* Search.storyboard */; };
 		3F1292FA1FD7CC1100ED5593 /* MovieListCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F1292F91FD7CC1100ED5593 /* MovieListCell.swift */; };
 		3F3BC2611FF40387000C7EC7 /* String+DateFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F3BC2601FF40387000C7EC7 /* String+DateFormatter.swift */; };
+		3F5E0D8C20308FF700E091BE /* SettingsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F5E0D8B20308FF700E091BE /* SettingsViewController.swift */; };
+		3F5E0D8F2030905B00E091BE /* SettingsCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F5E0D8E2030905B00E091BE /* SettingsCell.swift */; };
+		3F5E0D91203090C300E091BE /* SettingItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F5E0D90203090C300E091BE /* SettingItem.swift */; };
 		3F61B2FB1FFAD680007A0557 /* MoviesList.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 3F61B2FD1FFAD680007A0557 /* MoviesList.storyboard */; };
 		3F6C88792002B2C50052BF24 /* ImprintViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F6C88782002B2C50052BF24 /* ImprintViewController.swift */; };
-		3F6C887C2002B2FC0052BF24 /* Imprint.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 3F6C887A2002B2FC0052BF24 /* Imprint.storyboard */; };
+		3F6C887C2002B2FC0052BF24 /* Settings.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 3F6C887A2002B2FC0052BF24 /* Settings.storyboard */; };
 		3F6C887E2002B5090052BF24 /* MovieNightViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F6C887D2002B5090052BF24 /* MovieNightViewController.swift */; };
 		3F6C88812002B5400052BF24 /* MovieNight.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 3F6C887F2002B5400052BF24 /* MovieNight.storyboard */; };
 		3F71F685200292B700496E05 /* TextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F71F684200292B700496E05 /* TextView.swift */; };
@@ -84,10 +87,13 @@
 		3F1292F81FD7C9AA00ED5593 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/Main.strings; sourceTree = "<group>"; };
 		3F1292F91FD7CC1100ED5593 /* MovieListCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MovieListCell.swift; sourceTree = "<group>"; };
 		3F3BC2601FF40387000C7EC7 /* String+DateFormatter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+DateFormatter.swift"; sourceTree = "<group>"; };
+		3F5E0D8B20308FF700E091BE /* SettingsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsViewController.swift; sourceTree = "<group>"; };
+		3F5E0D8E2030905B00E091BE /* SettingsCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsCell.swift; sourceTree = "<group>"; };
+		3F5E0D90203090C300E091BE /* SettingItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingItem.swift; sourceTree = "<group>"; };
 		3F61B2FC1FFAD680007A0557 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/MoviesList.storyboard; sourceTree = "<group>"; };
 		3F61B2FF1FFAD683007A0557 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/MoviesList.strings; sourceTree = "<group>"; };
 		3F6C88782002B2C50052BF24 /* ImprintViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImprintViewController.swift; sourceTree = "<group>"; };
-		3F6C887B2002B2FC0052BF24 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Imprint.storyboard; sourceTree = "<group>"; };
+		3F6C887B2002B2FC0052BF24 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Settings.storyboard; sourceTree = "<group>"; };
 		3F6C887D2002B5090052BF24 /* MovieNightViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MovieNightViewController.swift; sourceTree = "<group>"; };
 		3F6C88802002B5400052BF24 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/MovieNight.storyboard; sourceTree = "<group>"; };
 		3F71F684200292B700496E05 /* TextView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextView.swift; sourceTree = "<group>"; };
@@ -174,6 +180,16 @@
 				3F71F684200292B700496E05 /* TextView.swift */,
 			);
 			path = "Custom UI";
+			sourceTree = "<group>";
+		};
+		3F5E0D8D2030900200E091BE /* Settings */ = {
+			isa = PBXGroup;
+			children = (
+				3F5E0D8B20308FF700E091BE /* SettingsViewController.swift */,
+				3F5E0D8E2030905B00E091BE /* SettingsCell.swift */,
+				3F6C88782002B2C50052BF24 /* ImprintViewController.swift */,
+			);
+			path = Settings;
 			sourceTree = "<group>";
 		};
 		3F8644AC1FFA8F590046114A /* CoreDataHelper */ = {
@@ -329,7 +345,7 @@
 				959E8B741FABC6CD0004E8C3 /* MyMovies */,
 				959E8B751FABC6DB0004E8C3 /* SearchMovies */,
 				95B24EF31FADDB070070912A /* MovieDetail */,
-				3F6C88782002B2C50052BF24 /* ImprintViewController.swift */,
+				3F5E0D8D2030900200E091BE /* Settings */,
 				3F6C887D2002B5090052BF24 /* MovieNightViewController.swift */,
 			);
 			path = ViewController;
@@ -343,7 +359,7 @@
 				3F1292EF1FD7C90C00ED5593 /* Search.storyboard */,
 				3F1292ED1FD7C90C00ED5593 /* MovieDetail.storyboard */,
 				95AE25A81F9531E20067F5F5 /* LaunchScreen.storyboard */,
-				3F6C887A2002B2FC0052BF24 /* Imprint.storyboard */,
+				3F6C887A2002B2FC0052BF24 /* Settings.storyboard */,
 				3F6C887F2002B5400052BF24 /* MovieNight.storyboard */,
 			);
 			path = Storyboards;
@@ -356,6 +372,7 @@
 				95F0DBC81F9D2CF9004681C7 /* PagedMovieResult.swift */,
 				9552262C1FAFB5D300323982 /* StoredMovie.swift */,
 				95B57719201E2C75007BD9F0 /* MovieListCategory.swift */,
+				3F5E0D90203090C300E091BE /* SettingItem.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -465,7 +482,7 @@
 				9583289A1FBB81340084CF80 /* cineaste.xcassets in Resources */,
 				95D32F611F9AA20100497ED2 /* apikey.plist in Resources */,
 				95AE25A51F9531E20067F5F5 /* Main.storyboard in Resources */,
-				3F6C887C2002B2FC0052BF24 /* Imprint.storyboard in Resources */,
+				3F6C887C2002B2FC0052BF24 /* Settings.storyboard in Resources */,
 				3F1292F21FD7C90D00ED5593 /* Search.storyboard in Resources */,
 				3F6C88812002B5400052BF24 /* MovieNight.storyboard in Resources */,
 				3F1292F11FD7C90D00ED5593 /* MovieDetail.storyboard in Resources */,
@@ -621,6 +638,7 @@
 				95F0DBC91F9D2CF9004681C7 /* PagedMovieResult.swift in Sources */,
 				3FCC71371FD7536B00A47ADF /* FetchedResultsManagerDelegate.swift in Sources */,
 				3F8644AB1FFA72EE0046114A /* MoviesTabBarController.swift in Sources */,
+				3F5E0D91203090C300E091BE /* SettingItem.swift in Sources */,
 				95B5771A201E2C75007BD9F0 /* MovieListCategory.swift in Sources */,
 				9552262D1FAFB5D300323982 /* StoredMovie.swift in Sources */,
 				9528112E201D05AD00F3EC76 /* Result.swift in Sources */,
@@ -630,6 +648,7 @@
 				3F059D471FF3FA8B00D5576B /* Label.swift in Sources */,
 				95EFA4B01FA13AAA004F1F94 /* Resource.swift in Sources */,
 				95D32F641F9AA2EA00497ED2 /* ApiKeyStore.swift in Sources */,
+				3F5E0D8F2030905B00E091BE /* SettingsCell.swift in Sources */,
 				3F8C569C1FFACAFF00F09A82 /* MovieStorage.swift in Sources */,
 				3F6C88792002B2C50052BF24 /* ImprintViewController.swift in Sources */,
 				95DC32051F97E1300014E3EA /* Model.xcdatamodeld in Sources */,
@@ -645,6 +664,7 @@
 				95AE25A01F9531E20067F5F5 /* AppDelegate.swift in Sources */,
 				3FA808D1200285590036357B /* View.swift in Sources */,
 				3FCC71331FD747D600A47ADF /* FetchedResultsManager.swift in Sources */,
+				3F5E0D8C20308FF700E091BE /* SettingsViewController.swift in Sources */,
 				3F3BC2611FF40387000C7EC7 /* String+DateFormatter.swift in Sources */,
 				3F8644A91FFA69E70046114A /* MoviesViewController.swift in Sources */,
 				3FBD8F921FF3FC5B00AD5F02 /* Date+Formatter.swift in Sources */,
@@ -705,12 +725,12 @@
 			name = MoviesList.storyboard;
 			sourceTree = "<group>";
 		};
-		3F6C887A2002B2FC0052BF24 /* Imprint.storyboard */ = {
+		3F6C887A2002B2FC0052BF24 /* Settings.storyboard */ = {
 			isa = PBXVariantGroup;
 			children = (
 				3F6C887B2002B2FC0052BF24 /* Base */,
 			);
-			name = Imprint.storyboard;
+			name = Settings.storyboard;
 			sourceTree = "<group>";
 		};
 		3F6C887F2002B5400052BF24 /* MovieNight.storyboard */ = {

--- a/Cineaste/Models/SettingItem.swift
+++ b/Cineaste/Models/SettingItem.swift
@@ -1,0 +1,42 @@
+//
+//  SettingItem.swift
+//  Cineaste
+//
+//  Created by Felizia Bernutz on 11.02.18.
+//  Copyright © 2018 notimeforthat.org. All rights reserved.
+//
+
+import UIKit
+
+enum SettingItem {
+    case exportMovies
+    case importMovies
+    case licence
+    case about
+
+    var title: String {
+        switch self {
+        case .exportMovies:
+            return NSLocalizedString("Export", comment: "Title for settings cell exportMovies")
+        case .importMovies:
+            return NSLocalizedString("Import", comment: "Title for settings cell importMovies")
+        case .licence:
+            return NSLocalizedString("Lizenzen", comment: "Title for settings cell licence")
+        case .about:
+            return NSLocalizedString("Impressum", comment: "Title for settings cell about")
+        }
+    }
+
+    var segue: Segue? {
+        switch self {
+        case .exportMovies:
+            return nil
+        case .importMovies:
+            return nil
+        case .licence:
+            return nil
+        case .about:
+            return Segue.showImprintFromSettings
+        }
+    }
+}

--- a/Cineaste/Models/SettingItem.swift
+++ b/Cineaste/Models/SettingItem.swift
@@ -23,7 +23,7 @@ enum SettingItem {
         case .licence:
             return NSLocalizedString("Lizenzen", comment: "Title for settings cell licence")
         case .about:
-            return NSLocalizedString("Impressum", comment: "Title for settings cell about")
+            return NSLocalizedString("Über die App", comment: "Title for settings cell about")
         }
     }
 
@@ -34,9 +34,9 @@ enum SettingItem {
         case .importMovies:
             return nil
         case .licence:
-            return nil
+            return Segue.showTextViewFromSettings
         case .about:
-            return Segue.showImprintFromSettings
+            return Segue.showTextViewFromSettings
         }
     }
 }

--- a/Cineaste/Models/TextViewContent.swift
+++ b/Cineaste/Models/TextViewContent.swift
@@ -6,4 +6,23 @@
 //  Copyright © 2018 notimeforthat.org. All rights reserved.
 //
 
-import Foundation
+import UIKit
+
+//swiftlint:disable line_length
+enum TextViewContent {
+    case imprint
+    case licence
+
+    var content: String {
+        switch self {
+        case .imprint:
+            return """
+            Cineaste ist ein Open Source Projekt von zwei Informatik Studenten. Das Kernfeature der App liegt darin, möglichst leicht Filme für einen gemeinsamen Filmeabend zu finden. Über den "Matching"-Button sucht dein Handy nach Freunden in deiner Umgebung und findet Filme, die ihr Alle sehen wollt.\n\nDie Daten werden dabei über Bluetooth übertragen. Das heißt, dass deine Filmlisten zu jedem Zeitpunkt sicher auf deinem Gerät sind und dort auch bleiben. Daten werden also nur innerhalb deines Wohnzimmers ausgetauscht.\n\nCineaste befindet sich noch im Anfangsstadium und könnte manchmal nicht richtig funktionieren. Natürlich geben wir unser Bestes um das Erlebnis so gut wie möglich zu machen, dabei sind wir aber auf dein Feedback angewiesen. Schreib doch einfach ein Kommentar im Play Store oder entwickle einfach gemeinsam mit uns Cineaste weiter! Dazu findest du unten das GitHub Icon. Für die Filme zapfen wir übrigens TheMovieDb an. Auch hier kannst du über das Icon mal vorbeischaun.\n\nBesonderer Dank geht an Philipp Wolf für das Design!
+            """
+        case .licence:
+            return """
+            Lorem ipsum dolor sit er elit lamet, consectetaur cillium adipisicing pecu, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. Nam liber te conscient to factor tum poen legum odioque civiuda.
+            """
+        }
+    }
+}

--- a/Cineaste/Models/TextViewContent.swift
+++ b/Cineaste/Models/TextViewContent.swift
@@ -1,0 +1,9 @@
+//
+//  TextViewContent.swift
+//  Cineaste
+//
+//  Created by Felizia Bernutz on 11.02.18.
+//  Copyright © 2018 notimeforthat.org. All rights reserved.
+//
+
+import Foundation

--- a/Cineaste/Storyboards/Base.lproj/Settings.storyboard
+++ b/Cineaste/Storyboards/Base.lproj/Settings.storyboard
@@ -42,7 +42,57 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="eD8-Wo-mol" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="-28" y="-2.2488755622188905"/>
+            <point key="canvasLocation" x="682" y="-2"/>
+        </scene>
+        <!--Settings View Controller-->
+        <scene sceneID="mPh-4Z-1Sc">
+            <objects>
+                <tableViewController storyboardIdentifier="SettingsViewController" id="Rur-D2-VnD" customClass="SettingsViewController" customModule="Cineaste" customModuleProvider="target" sceneMemberID="viewController">
+                    <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" id="Wdh-qQ-edX">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                        <prototypes>
+                            <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="SettingsCell" rowHeight="76" id="rdE-YT-vP0" customClass="SettingsCell" customModule="Cineaste" customModuleProvider="target">
+                                <rect key="frame" x="0.0" y="28" width="375" height="76"/>
+                                <autoresizingMask key="autoresizingMask"/>
+                                <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="rdE-YT-vP0" id="vcO-qi-UIq">
+                                    <rect key="frame" x="0.0" y="0.0" width="375" height="75.5"/>
+                                    <autoresizingMask key="autoresizingMask"/>
+                                    <subviews>
+                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="jOy-70-BtQ" customClass="TitleLabel" customModule="Cineaste" customModuleProvider="target">
+                                            <rect key="frame" x="20" y="20" width="335" height="35"/>
+                                            <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                            <nil key="textColor"/>
+                                            <nil key="highlightedColor"/>
+                                        </label>
+                                    </subviews>
+                                    <constraints>
+                                        <constraint firstAttribute="trailing" secondItem="jOy-70-BtQ" secondAttribute="trailing" constant="20" symbolic="YES" id="La5-yM-DnG"/>
+                                        <constraint firstItem="jOy-70-BtQ" firstAttribute="top" secondItem="vcO-qi-UIq" secondAttribute="top" constant="20" symbolic="YES" id="TjX-gp-gxL"/>
+                                        <constraint firstItem="jOy-70-BtQ" firstAttribute="leading" secondItem="vcO-qi-UIq" secondAttribute="leading" constant="20" symbolic="YES" id="WqK-Wa-OP9"/>
+                                        <constraint firstItem="jOy-70-BtQ" firstAttribute="centerY" secondItem="vcO-qi-UIq" secondAttribute="centerY" id="qMs-mC-Nv9"/>
+                                    </constraints>
+                                </tableViewCellContentView>
+                                <connections>
+                                    <outlet property="title" destination="jOy-70-BtQ" id="zfN-6O-tfq"/>
+                                </connections>
+                            </tableViewCell>
+                        </prototypes>
+                        <sections/>
+                        <connections>
+                            <outlet property="dataSource" destination="Rur-D2-VnD" id="rYV-st-OJp"/>
+                            <outlet property="delegate" destination="Rur-D2-VnD" id="cKA-LH-R4T"/>
+                        </connections>
+                    </tableView>
+                    <navigationItem key="navigationItem" id="cjP-qO-SH6"/>
+                    <connections>
+                        <segue destination="yN8-JU-i4Y" kind="show" identifier="showImprintFromSettingsSegue" id="9fG-4F-a8p"/>
+                    </connections>
+                </tableViewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="0yu-L6-LZW" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="-80.799999999999997" y="-2.2488755622188905"/>
         </scene>
         <!--Navigation Controller-->
         <scene sceneID="P32-5u-VwN">
@@ -55,7 +105,7 @@
                     </navigationBar>
                     <nil name="viewControllers"/>
                     <connections>
-                        <segue destination="yN8-JU-i4Y" kind="relationship" relationship="rootViewController" id="38U-Er-ifd"/>
+                        <segue destination="Rur-D2-VnD" kind="relationship" relationship="rootViewController" id="tnb-K7-Izx"/>
                     </connections>
                 </navigationController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="iQe-GH-vwl" userLabel="First Responder" sceneMemberID="firstResponder"/>

--- a/Cineaste/Storyboards/Base.lproj/Settings.storyboard
+++ b/Cineaste/Storyboards/Base.lproj/Settings.storyboard
@@ -87,7 +87,7 @@
                     </tableView>
                     <navigationItem key="navigationItem" id="cjP-qO-SH6"/>
                     <connections>
-                        <segue destination="yN8-JU-i4Y" kind="show" identifier="showImprintFromSettingsSegue" id="9fG-4F-a8p"/>
+                        <segue destination="yN8-JU-i4Y" kind="show" identifier="showTextViewFromSettingsSegue" id="9fG-4F-a8p"/>
                     </connections>
                 </tableViewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="0yu-L6-LZW" userLabel="First Responder" sceneMemberID="firstResponder"/>

--- a/Cineaste/Storyboards/Base.lproj/Settings.storyboard
+++ b/Cineaste/Storyboards/Base.lproj/Settings.storyboard
@@ -45,54 +45,73 @@
             <point key="canvasLocation" x="682" y="-2"/>
         </scene>
         <!--Settings View Controller-->
-        <scene sceneID="mPh-4Z-1Sc">
+        <scene sceneID="euU-pz-XTd">
             <objects>
-                <tableViewController storyboardIdentifier="SettingsViewController" id="Rur-D2-VnD" customClass="SettingsViewController" customModule="Cineaste" customModuleProvider="target" sceneMemberID="viewController">
-                    <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" id="Wdh-qQ-edX">
+                <viewController storyboardIdentifier="SettingsViewController" id="AYh-ap-7p0" customClass="SettingsViewController" customModule="Cineaste" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="MJK-U3-9om">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="6qY-Yg-OwE">
+                                <rect key="frame" x="0.0" y="64" width="375" height="542"/>
+                                <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                <prototypes>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="SettingsCell" rowHeight="76" id="rdE-YT-vP0" customClass="SettingsCell" customModule="Cineaste" customModuleProvider="target">
+                                        <rect key="frame" x="0.0" y="28" width="375" height="76"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="rdE-YT-vP0" id="vcO-qi-UIq">
+                                            <rect key="frame" x="0.0" y="0.0" width="375" height="75.5"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="jOy-70-BtQ" customClass="TitleLabel" customModule="Cineaste" customModuleProvider="target">
+                                                    <rect key="frame" x="20" y="20" width="335" height="35"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                    <nil key="textColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                            </subviews>
+                                            <constraints>
+                                                <constraint firstAttribute="trailing" secondItem="jOy-70-BtQ" secondAttribute="trailing" constant="20" symbolic="YES" id="La5-yM-DnG"/>
+                                                <constraint firstItem="jOy-70-BtQ" firstAttribute="top" secondItem="vcO-qi-UIq" secondAttribute="top" constant="20" symbolic="YES" id="TjX-gp-gxL"/>
+                                                <constraint firstItem="jOy-70-BtQ" firstAttribute="leading" secondItem="vcO-qi-UIq" secondAttribute="leading" constant="20" symbolic="YES" id="WqK-Wa-OP9"/>
+                                                <constraint firstItem="jOy-70-BtQ" firstAttribute="centerY" secondItem="vcO-qi-UIq" secondAttribute="centerY" id="qMs-mC-Nv9"/>
+                                            </constraints>
+                                        </tableViewCellContentView>
+                                        <connections>
+                                            <outlet property="title" destination="jOy-70-BtQ" id="zfN-6O-tfq"/>
+                                        </connections>
+                                    </tableViewCell>
+                                </prototypes>
+                            </tableView>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="dHV-Zu-EIw" customClass="DescriptionLabel" customModule="Cineaste" customModuleProvider="target">
+                                <rect key="frame" x="10" y="626" width="355" height="21"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                        </subviews>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                        <prototypes>
-                            <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="SettingsCell" rowHeight="76" id="rdE-YT-vP0" customClass="SettingsCell" customModule="Cineaste" customModuleProvider="target">
-                                <rect key="frame" x="0.0" y="28" width="375" height="76"/>
-                                <autoresizingMask key="autoresizingMask"/>
-                                <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="rdE-YT-vP0" id="vcO-qi-UIq">
-                                    <rect key="frame" x="0.0" y="0.0" width="375" height="75.5"/>
-                                    <autoresizingMask key="autoresizingMask"/>
-                                    <subviews>
-                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="jOy-70-BtQ" customClass="TitleLabel" customModule="Cineaste" customModuleProvider="target">
-                                            <rect key="frame" x="20" y="20" width="335" height="35"/>
-                                            <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                            <nil key="textColor"/>
-                                            <nil key="highlightedColor"/>
-                                        </label>
-                                    </subviews>
-                                    <constraints>
-                                        <constraint firstAttribute="trailing" secondItem="jOy-70-BtQ" secondAttribute="trailing" constant="20" symbolic="YES" id="La5-yM-DnG"/>
-                                        <constraint firstItem="jOy-70-BtQ" firstAttribute="top" secondItem="vcO-qi-UIq" secondAttribute="top" constant="20" symbolic="YES" id="TjX-gp-gxL"/>
-                                        <constraint firstItem="jOy-70-BtQ" firstAttribute="leading" secondItem="vcO-qi-UIq" secondAttribute="leading" constant="20" symbolic="YES" id="WqK-Wa-OP9"/>
-                                        <constraint firstItem="jOy-70-BtQ" firstAttribute="centerY" secondItem="vcO-qi-UIq" secondAttribute="centerY" id="qMs-mC-Nv9"/>
-                                    </constraints>
-                                </tableViewCellContentView>
-                                <connections>
-                                    <outlet property="title" destination="jOy-70-BtQ" id="zfN-6O-tfq"/>
-                                </connections>
-                            </tableViewCell>
-                        </prototypes>
-                        <sections/>
-                        <connections>
-                            <outlet property="dataSource" destination="Rur-D2-VnD" id="rYV-st-OJp"/>
-                            <outlet property="delegate" destination="Rur-D2-VnD" id="cKA-LH-R4T"/>
-                        </connections>
-                    </tableView>
-                    <navigationItem key="navigationItem" id="cjP-qO-SH6"/>
+                        <constraints>
+                            <constraint firstItem="dHV-Zu-EIw" firstAttribute="leading" secondItem="yp4-ve-i9U" secondAttribute="leading" constant="10" id="566-Fa-jcx"/>
+                            <constraint firstItem="yp4-ve-i9U" firstAttribute="trailing" secondItem="6qY-Yg-OwE" secondAttribute="trailing" id="5Xi-oo-4VC"/>
+                            <constraint firstItem="dHV-Zu-EIw" firstAttribute="top" secondItem="6qY-Yg-OwE" secondAttribute="bottom" constant="20" id="64x-LB-Mu3"/>
+                            <constraint firstItem="6qY-Yg-OwE" firstAttribute="leading" secondItem="yp4-ve-i9U" secondAttribute="leading" id="6H6-ua-cRD"/>
+                            <constraint firstItem="yp4-ve-i9U" firstAttribute="bottom" secondItem="dHV-Zu-EIw" secondAttribute="bottom" constant="20" id="98Z-u0-Fdu"/>
+                            <constraint firstItem="yp4-ve-i9U" firstAttribute="trailing" secondItem="dHV-Zu-EIw" secondAttribute="trailing" constant="10" id="PIU-eO-02M"/>
+                            <constraint firstItem="6qY-Yg-OwE" firstAttribute="top" secondItem="yp4-ve-i9U" secondAttribute="top" id="uI2-V9-AQ4"/>
+                        </constraints>
+                        <viewLayoutGuide key="safeArea" id="yp4-ve-i9U"/>
+                    </view>
+                    <navigationItem key="navigationItem" id="Ffr-1f-9W7"/>
                     <connections>
-                        <segue destination="yN8-JU-i4Y" kind="show" identifier="showTextViewFromSettingsSegue" id="9fG-4F-a8p"/>
+                        <outlet property="settingsTableView" destination="6qY-Yg-OwE" id="CJW-aJ-SpX"/>
+                        <outlet property="versionInfo" destination="dHV-Zu-EIw" id="klT-kd-mnF"/>
+                        <segue destination="yN8-JU-i4Y" kind="show" identifier="showTextViewFromSettingsSegue" id="fBL-qA-hfW"/>
                     </connections>
-                </tableViewController>
-                <placeholder placeholderIdentifier="IBFirstResponder" id="0yu-L6-LZW" userLabel="First Responder" sceneMemberID="firstResponder"/>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="dMd-nL-CH8" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="-80.799999999999997" y="-2.2488755622188905"/>
+            <point key="canvasLocation" x="-68" y="-2"/>
         </scene>
         <!--Navigation Controller-->
         <scene sceneID="P32-5u-VwN">
@@ -105,7 +124,7 @@
                     </navigationBar>
                     <nil name="viewControllers"/>
                     <connections>
-                        <segue destination="Rur-D2-VnD" kind="relationship" relationship="rootViewController" id="tnb-K7-Izx"/>
+                        <segue destination="AYh-ap-7p0" kind="relationship" relationship="rootViewController" id="zLo-lP-fme"/>
                     </connections>
                 </navigationController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="iQe-GH-vwl" userLabel="First Responder" sceneMemberID="firstResponder"/>

--- a/Cineaste/Utils/Segue.swift
+++ b/Cineaste/Utils/Segue.swift
@@ -10,7 +10,7 @@ import UIKit
 
 enum Segue: String {
     case showMovieDetail = "ShowMovieDetailSegue"
-    case showImprintFromSettings = "showImprintFromSettingsSegue"
+    case showTextViewFromSettings = "showTextViewFromSettingsSegue"
 
     init?(initWith segue: UIStoryboardSegue) {
         guard let identifier = segue.identifier else { fatalError("Segue identifier not found.") }

--- a/Cineaste/Utils/Segue.swift
+++ b/Cineaste/Utils/Segue.swift
@@ -10,6 +10,7 @@ import UIKit
 
 enum Segue: String {
     case showMovieDetail = "ShowMovieDetailSegue"
+    case showImprintFromSettings = "showImprintFromSettingsSegue"
 
     init?(initWith segue: UIStoryboardSegue) {
         guard let identifier = segue.identifier else { fatalError("Segue identifier not found.") }

--- a/Cineaste/Utils/Storyboard.swift
+++ b/Cineaste/Utils/Storyboard.swift
@@ -13,7 +13,7 @@ enum Storyboard: String {
     case movieList = "MoviesList"
     case search = "Search"
     case movieDetail = "MovieDetail"
-    case imprint = "Imprint"
+    case settings = "Settings"
     case movieNight = "MovieNight"
 }
 

--- a/Cineaste/ViewController/MoviesTabBarController.swift
+++ b/Cineaste/ViewController/MoviesTabBarController.swift
@@ -27,11 +27,11 @@ class MoviesTabBarController: UITabBarController {
         movieNightVC.tabBarItem = UITabBarItem(title: "Movie-Night", image: nil, tag: 2)
         let movieNightVCWithNavi = UINavigationController(rootViewController: movieNightVC)
 
-        let imprintVC = ImprintViewController.instantiate()
-        imprintVC.tabBarItem = UITabBarItem(title: "About", image: nil, tag: 3)
-        let imprintVCWithNavi = UINavigationController(rootViewController: imprintVC)
+        let settingsVC = SettingsViewController.instantiate()
+        settingsVC.tabBarItem = UITabBarItem(title: "Settings", image: nil, tag: 3)
+        let settingsVCWithNavi = UINavigationController(rootViewController: settingsVC)
 
-        viewControllers = [wantToSeeVCWithNavi, seenVCWithNavi, movieNightVCWithNavi, imprintVCWithNavi]
+        viewControllers = [wantToSeeVCWithNavi, seenVCWithNavi, movieNightVCWithNavi, settingsVCWithNavi]
     }
 }
 

--- a/Cineaste/ViewController/SearchMovies/SearchMoviesViewController.swift
+++ b/Cineaste/ViewController/SearchMovies/SearchMoviesViewController.swift
@@ -71,6 +71,8 @@ class SearchMoviesViewController: UIViewController {
         case .showMovieDetail:
             let vc = segue.destination as? MovieDetailViewController
             vc?.movie = selectedMovie
+        default:
+            return
         }
     }
 

--- a/Cineaste/ViewController/Settings/ImprintViewController.swift
+++ b/Cineaste/ViewController/Settings/ImprintViewController.swift
@@ -20,6 +20,6 @@ class ImprintViewController: UIViewController {
 }
 
 extension ImprintViewController: Instantiable {
-    static var storyboard: Storyboard { return .imprint }
+    static var storyboard: Storyboard { return .settings }
     static var storyboardID: String? { return "ImprintViewController" }
 }

--- a/Cineaste/ViewController/Settings/ImprintViewController.swift
+++ b/Cineaste/ViewController/Settings/ImprintViewController.swift
@@ -9,12 +9,17 @@
 import UIKit
 
 class ImprintViewController: UIViewController {
-    @IBOutlet var imprintTextView: UITextView!
+    @IBOutlet var imprintTextView: UITextView! {
+        didSet {
+            imprintTextView.text = textViewContent.content
+        }
+    }
+
+    var textViewContent: TextViewContent = .imprint
 
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        title = NSLocalizedString("About", comment: "Title for imprint viewController")
     }
 
 }

--- a/Cineaste/ViewController/Settings/SettingsCell.swift
+++ b/Cineaste/ViewController/Settings/SettingsCell.swift
@@ -1,0 +1,20 @@
+//
+//  SettingsCell.swift
+//  Cineaste
+//
+//  Created by Felizia Bernutz on 11.02.18.
+//  Copyright © 2018 notimeforthat.org. All rights reserved.
+//
+
+import UIKit
+
+class SettingsCell: UITableViewCell {
+    static let identifier = "SettingsCell"
+
+    @IBOutlet var title: TitleLabel!
+
+    func configure(with settingsItem: SettingItem) {
+        title.text = settingsItem.title
+    }
+
+}

--- a/Cineaste/ViewController/Settings/SettingsViewController.swift
+++ b/Cineaste/ViewController/Settings/SettingsViewController.swift
@@ -20,10 +20,11 @@ class SettingsViewController: UIViewController {
 
     @IBOutlet var versionInfo: DescriptionLabel!
 
-    var settings: [SettingItem] = [SettingItem.about,
-                                   SettingItem.licence,
-                                   SettingItem.exportMovies,
-                                   SettingItem.importMovies]
+    var settings: [SettingItem] = [] {
+        didSet {
+            settingsTableView.reloadData()
+        }
+    }
 
     var selectedSetting: SettingItem?
 
@@ -33,6 +34,11 @@ class SettingsViewController: UIViewController {
         title = NSLocalizedString("Einstellungen", comment: "Title for settings viewController")
 
         view.backgroundColor = UIColor.basicBackground
+
+        settings = [SettingItem.about,
+                    SettingItem.licence,
+                    SettingItem.exportMovies,
+                    SettingItem.importMovies]
 
         versionInfo?.text = versionString()
     }
@@ -59,8 +65,7 @@ class SettingsViewController: UIViewController {
         case .showTextViewFromSettings:
             let vc = segue.destination as? ImprintViewController
             vc?.title = selected.title
-            vc?.textViewContent =
-                (selected == SettingItem.licence)
+            vc?.textViewContent = (selected == SettingItem.licence)
                 ? TextViewContent.licence
                 : TextViewContent.imprint
         default:

--- a/Cineaste/ViewController/Settings/SettingsViewController.swift
+++ b/Cineaste/ViewController/Settings/SettingsViewController.swift
@@ -1,0 +1,71 @@
+//
+//  SettingsViewController.swift
+//  Cineaste
+//
+//  Created by Felizia Bernutz on 11.02.18.
+//  Copyright © 2018 notimeforthat.org. All rights reserved.
+//
+
+import UIKit
+
+class SettingsViewController: UITableViewController {
+
+    var settings: [SettingItem] = [SettingItem.about,
+                                   SettingItem.licence,
+                                   SettingItem.exportMovies,
+                                   SettingItem.importMovies]
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        title = NSLocalizedString("Einstellungen", comment: "Title for settings viewController")
+
+        view.backgroundColor = UIColor.basicBackground
+        tableView.backgroundColor = UIColor.basicBackground
+        tableView.tableFooterView = UIView()
+    }
+
+    // MARK: - Table view data source
+
+    override func numberOfSections(in tableView: UITableView) -> Int {
+        return 1
+    }
+
+    override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        return settings.count
+    }
+
+    override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        guard let cell = tableView.dequeueReusableCell(withIdentifier: SettingsCell.identifier, for: indexPath) as? SettingsCell else {
+            fatalError("Unable to dequeue cell for identifier: \(SettingsCell.identifier)")
+        }
+
+        if settings[indexPath.row].segue == nil {
+            cell.accessoryType = .none
+        } else {
+            cell.accessoryType = .disclosureIndicator
+        }
+
+        cell.configure(with: settings[indexPath.row])
+
+        return cell
+    }
+
+    override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        tableView.deselectRow(at: indexPath, animated: true)
+
+        if let segue = settings[indexPath.row].segue {
+            perform(segue: segue, sender: self)
+        } else {
+            let alert = UIAlertController(title: "Info", message: "Feature isn't implemented", preferredStyle: .alert)
+            let okAction = UIAlertAction(title: "Ok", style: .default, handler: nil)
+            alert.addAction(okAction)
+            present(alert, animated: true, completion: nil)
+        }
+    }
+}
+
+extension SettingsViewController: Instantiable {
+    static var storyboard: Storyboard { return .settings }
+    static var storyboardID: String? { return "SettingsViewController" }
+}

--- a/Cineaste/ViewController/Settings/SettingsViewController.swift
+++ b/Cineaste/ViewController/Settings/SettingsViewController.swift
@@ -33,6 +33,17 @@ class SettingsViewController: UIViewController {
         title = NSLocalizedString("Einstellungen", comment: "Title for settings viewController")
 
         view.backgroundColor = UIColor.basicBackground
+
+        versionInfo?.text = versionString()
+    }
+
+    func versionString() -> String {
+        guard
+            let version = Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String,
+            let build = Bundle.main.object(forInfoDictionaryKey: kCFBundleVersionKey as String) as? String
+            else { return "" }
+        let versionText = NSLocalizedString("Version", comment: "Description for app version")
+        return "\(versionText): \(version) (\(build))"
     }
 
     // MARK: - Navigation

--- a/Cineaste/ViewController/Settings/SettingsViewController.swift
+++ b/Cineaste/ViewController/Settings/SettingsViewController.swift
@@ -8,7 +8,17 @@
 
 import UIKit
 
-class SettingsViewController: UITableViewController {
+class SettingsViewController: UIViewController {
+    @IBOutlet var settingsTableView: UITableView! {
+        didSet {
+            settingsTableView.dataSource = self
+            settingsTableView.delegate = self
+            settingsTableView.backgroundColor = UIColor.basicBackground
+            settingsTableView.tableFooterView = UIView()
+        }
+    }
+
+    @IBOutlet var versionInfo: DescriptionLabel!
 
     var settings: [SettingItem] = [SettingItem.about,
                                    SettingItem.licence,
@@ -23,48 +33,6 @@ class SettingsViewController: UITableViewController {
         title = NSLocalizedString("Einstellungen", comment: "Title for settings viewController")
 
         view.backgroundColor = UIColor.basicBackground
-        tableView.backgroundColor = UIColor.basicBackground
-        tableView.tableFooterView = UIView()
-    }
-
-    // MARK: - Table view data source
-
-    override func numberOfSections(in tableView: UITableView) -> Int {
-        return 1
-    }
-
-    override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        return settings.count
-    }
-
-    override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        guard let cell = tableView.dequeueReusableCell(withIdentifier: SettingsCell.identifier, for: indexPath) as? SettingsCell else {
-            fatalError("Unable to dequeue cell for identifier: \(SettingsCell.identifier)")
-        }
-
-        if settings[indexPath.row].segue == nil {
-            cell.accessoryType = .none
-        } else {
-            cell.accessoryType = .disclosureIndicator
-        }
-
-        cell.configure(with: settings[indexPath.row])
-
-        return cell
-    }
-
-    override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
-        tableView.deselectRow(at: indexPath, animated: true)
-        selectedSetting = settings[indexPath.row]
-
-        if let segue = selectedSetting?.segue {
-            perform(segue: segue, sender: self)
-        } else {
-            let alert = UIAlertController(title: "Info", message: "Feature isn't implemented", preferredStyle: .alert)
-            let okAction = UIAlertAction(title: "Ok", style: .default, handler: nil)
-            alert.addAction(okAction)
-            present(alert, animated: true, completion: nil)
-        }
     }
 
     // MARK: - Navigation
@@ -86,6 +54,48 @@ class SettingsViewController: UITableViewController {
                 : TextViewContent.imprint
         default:
             return
+        }
+    }
+}
+
+extension SettingsViewController: UITableViewDataSource {
+    func numberOfSections(in tableView: UITableView) -> Int {
+        return 1
+    }
+
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        return settings.count
+    }
+
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        guard let cell = tableView.dequeueReusableCell(withIdentifier: SettingsCell.identifier, for: indexPath) as? SettingsCell else {
+            fatalError("Unable to dequeue cell for identifier: \(SettingsCell.identifier)")
+        }
+
+        if settings[indexPath.row].segue == nil {
+            cell.accessoryType = .none
+        } else {
+            cell.accessoryType = .disclosureIndicator
+        }
+
+        cell.configure(with: settings[indexPath.row])
+
+        return cell
+    }
+}
+
+extension SettingsViewController: UITableViewDelegate {
+    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        tableView.deselectRow(at: indexPath, animated: true)
+        selectedSetting = settings[indexPath.row]
+
+        if let segue = selectedSetting?.segue {
+            perform(segue: segue, sender: self)
+        } else {
+            let alert = UIAlertController(title: "Info", message: "Feature isn't implemented", preferredStyle: .alert)
+            let okAction = UIAlertAction(title: "Ok", style: .default, handler: nil)
+            alert.addAction(okAction)
+            present(alert, animated: true, completion: nil)
         }
     }
 }

--- a/Cineaste/ViewController/Settings/SettingsViewController.swift
+++ b/Cineaste/ViewController/Settings/SettingsViewController.swift
@@ -15,6 +15,8 @@ class SettingsViewController: UITableViewController {
                                    SettingItem.exportMovies,
                                    SettingItem.importMovies]
 
+    var selectedSetting: SettingItem?
+
     override func viewDidLoad() {
         super.viewDidLoad()
 
@@ -53,14 +55,37 @@ class SettingsViewController: UITableViewController {
 
     override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         tableView.deselectRow(at: indexPath, animated: true)
+        selectedSetting = settings[indexPath.row]
 
-        if let segue = settings[indexPath.row].segue {
+        if let segue = selectedSetting?.segue {
             perform(segue: segue, sender: self)
         } else {
             let alert = UIAlertController(title: "Info", message: "Feature isn't implemented", preferredStyle: .alert)
             let okAction = UIAlertAction(title: "Ok", style: .default, handler: nil)
             alert.addAction(okAction)
             present(alert, animated: true, completion: nil)
+        }
+    }
+
+    // MARK: - Navigation
+
+    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
+        guard let identifier = Segue(initWith: segue) else {
+            fatalError("unable to use Segue enum")
+        }
+
+        guard let selected = selectedSetting else { return }
+
+        switch identifier {
+        case .showTextViewFromSettings:
+            let vc = segue.destination as? ImprintViewController
+            vc?.title = selected.title
+            vc?.textViewContent =
+                (selected == SettingItem.licence)
+                ? TextViewContent.licence
+                : TextViewContent.imprint
+        default:
+            return
         }
     }
 }

--- a/CineasteTests/SettingsCellTests.swift
+++ b/CineasteTests/SettingsCellTests.swift
@@ -1,0 +1,32 @@
+//
+//  SettingsCellTests.swift
+//  CineasteTests
+//
+//  Created by Felizia Bernutz on 11.02.18.
+//  Copyright © 2018 notimeforthat.org. All rights reserved.
+//
+
+import XCTest
+@testable import Cineaste
+
+class SettingsCellTests: XCTestCase {
+    let cell = SettingsCell()
+
+    override func setUp() {
+        super.setUp()
+
+        let title = TitleLabel()
+        cell.addSubview(title)
+        cell.title = title
+    }
+
+    func testConfigureShouldSetCellTitleCorrectly() {
+        cell.configure(with: settingsItem)
+
+        XCTAssertEqual(cell.title.text, settingsItem.title)
+    }
+
+    private let settingsItem: SettingItem = {
+        return SettingItem.about
+    }()
+}

--- a/CineasteTests/SettingsViewControllerTests.swift
+++ b/CineasteTests/SettingsViewControllerTests.swift
@@ -1,0 +1,103 @@
+//
+//  SettingsViewControllerTests.swift
+//  CineasteTests
+//
+//  Created by Felizia Bernutz on 11.02.18.
+//  Copyright © 2018 notimeforthat.org. All rights reserved.
+//
+
+import XCTest
+@testable import Cineaste
+
+class SettingsViewControllerTests: XCTestCase {
+    let settingsVC = SettingsViewController.instantiate()
+
+    override func setUp() {
+        super.setUp()
+
+        settingsVC.settings = []
+    }
+
+    func testNumberOfSectionsShouldEqualOne() {
+        XCTAssertEqual(settingsVC.settingsTableView.numberOfSections, 1)
+    }
+
+    func testNumberOfRowsShouldEqualNumberOfSettingItems() {
+        XCTAssertEqual(settingsVC.settingsTableView.numberOfRows(inSection: 0), 0)
+
+        settingsVC.settings = settingsItems
+
+        XCTAssertEqual(settingsVC.settingsTableView.numberOfRows(inSection: 0), 2)
+    }
+
+    func testCellWithSegueShouldHaveDisclosureIndicator() {
+        settingsVC.settings = settingsItems
+
+        for row in 0..<settingsItems.count {
+            let path = IndexPath(row: row, section: 0)
+            let cell = settingsVC.settingsTableView.cellForRow(at: path)
+
+            if settingsItems[row].segue == nil {
+                XCTAssert(cell?.accessoryType == .none)
+            } else {
+                XCTAssert(cell?.accessoryType == .disclosureIndicator)
+            }
+        }
+    }
+
+    func testPrepareForSegueShouldInjectCorrectContent() {
+        let targetViewController = ImprintViewController.instantiate()
+        let targetSegue = UIStoryboardSegue(
+            identifier: Segue.showTextViewFromSettings.rawValue,
+            source: settingsVC,
+            destination: targetViewController)
+
+        //inject imprint data
+        let imprintItem = settingsItems[0]
+        settingsVC.selectedSetting = imprintItem
+        settingsVC.prepare(for: targetSegue, sender: settingsVC)
+
+        XCTAssertEqual(targetViewController.title, imprintItem.title)
+        XCTAssertEqual(targetViewController.textViewContent, .imprint)
+
+        //inject licence data
+        let licenceItem = settingsItems[1]
+        settingsVC.selectedSetting = licenceItem
+        settingsVC.prepare(for: targetSegue, sender: settingsVC)
+
+        XCTAssertEqual(targetViewController.title, licenceItem.title)
+        XCTAssertEqual(targetViewController.textViewContent, .licence)
+    }
+
+    func testSelectRowShouldSetCorrectSelectedSetting() {
+        settingsVC.settings = settingsItems
+        //nothing selected
+        XCTAssertNil(settingsVC.selectedSetting)
+
+        //select first row
+        let firstPath = IndexPath(row: 0, section: 0)
+        settingsVC.settingsTableView.delegate?.tableView!(settingsVC.settingsTableView, didSelectRowAt: firstPath)
+        XCTAssert(settingsVC.selectedSetting == settingsItems[firstPath.row])
+
+        //select second row
+        let secondPath = IndexPath(row: 1, section: 0)
+        settingsVC.settingsTableView.delegate?.tableView!(settingsVC.settingsTableView, didSelectRowAt: secondPath)
+        XCTAssert(settingsVC.selectedSetting == settingsItems[secondPath.row])
+    }
+
+    func testCellForRowShouldBeOfTypeSettingsCell() {
+        settingsVC.settings = settingsItems
+
+        for row in 0..<settingsItems.count {
+            let path = IndexPath(row: row, section: 0)
+            let cell = settingsVC.settingsTableView.cellForRow(at: path)
+
+            XCTAssert(cell is SettingsCell)
+        }
+    }
+
+    private let settingsItems: [SettingItem] = {
+        return [SettingItem.about,
+                SettingItem.licence]
+    }()
+}


### PR DESCRIPTION
- Add `SettingsViewController` as a `UIViewController` with a table view for displaying more than one single page for imprint
- Add `SettingsCell` with a title label and disclosureIndicator, only if a segue is set
- Add `SettingItem` enum for title and segue information for imprint/about, licence, export and import
- Add `TextViewContent` enum to display different data in the textView (for licence and about)
- Add tests for SettingsVC and SettingsCell